### PR TITLE
bug-fix: switchBranch was not behaving properly

### DIFF
--- a/include/head.h
+++ b/include/head.h
@@ -7,5 +7,7 @@ std::string getHead();
 void setHead(const std::string& commit_hash);
 std::string getBranchHash(const std::string& branch_name);
 void updateHead(const std::string& branch_name);
+bool isHeadDetached();
+std::string getHeadBranchName();
 
 #endif // !HEAD_HPP

--- a/src/commands/switch.cpp
+++ b/src/commands/switch.cpp
@@ -7,7 +7,6 @@
 #include <objects.h>
 
 void switchBranch(const std::string& branch_name){
-//TODO: implement logic of updating working dir based on branch 
   std::string repo_root = arkDir();
   std::string branch_path = repo_root + "/.ark/refs/heads/" + branch_name;
   if(!(std::filesystem::exists(branch_path) && std::filesystem::is_regular_file(branch_path))){
@@ -16,7 +15,8 @@ void switchBranch(const std::string& branch_name){
   }
   std::string source_commit_hash = getHead();
   std::string target_commit_hash = getBranchHash(branch_name);
-  if(source_commit_hash == target_commit_hash){
+  std::string source_branch_name = getHeadBranchName();
+  if(!isHeadDetached() && source_branch_name == branch_name){
     std::cerr<<"already on branch "<<branch_name<<std::endl;
     return;
   }

--- a/src/utils/head.cpp
+++ b/src/utils/head.cpp
@@ -30,6 +30,41 @@ std::string getHead(){
   return line;
 }
 
+std::string getHeadBranchName(){
+  std::string repo_root = arkDir();
+  std::string head_path = repo_root + "/.ark/HEAD";
+  std::ifstream in(head_path);
+  if(!in){
+    std::cerr<<"error finding HEAD\n";
+    return "";
+  }
+  std::string line;
+  getline(in,line);
+  if(line.rfind("ref: ",0) == 0){
+    std::string branch_name = line.substr(5);
+    return branch_name;
+  }
+  in.close();
+  return "";
+}
+
+bool isHeadDetached(){
+  std::string repo_root = arkDir();
+  std::string head_path = repo_root + "/.ark/HEAD";
+  std::ifstream in(head_path);
+  if(!in){
+    std::cerr<<"error finding HEAD\n";
+    return "";
+  }
+  std::string line;
+  getline(in,line);
+  if(line.rfind("ref: ",0) == 0){
+    return false;
+  }
+  in.close();
+  return true;
+}
+
 //use when wanna change head to point to a file in refs/heads
 void updateHead(const std::string& branch_name){
   std::string repo_root = arkDir();


### PR DESCRIPTION
Issue : ./ark switch won't switch the branch if both branched pointed to the same commit.

cause : the check in switchBranch func if(source_commit_hash == target_commit_hash) is not correct.

fix : changed the checking condition to if(!isHeadDetached() && source_branch_name == target_branch_name) 