### PR TITLE
fix log segmentaion fault

### DIFF
--- a/include/objects.h
+++ b/include/objects.h
@@ -1,97 +1,104 @@
 #ifndef OBJECTS_HPP
 #define OBJECTS_HPP
 
-#include <fstream>
-#include <string>
-#include <sstream>
-#include <openssl/sha.h>
+#include <ark.h>
 #include <compress.h>
+#include <fstream>
 #include <iostream>
+#include <openssl/sha.h>
+#include <sstream>
+#include <string>
 #include <unordered_map>
 #include <vector>
-#include <ark.h>
-
 
 class Object {
 public:
-    std::string mode;
-    std::string hash;
-    std::string content;
-    std::string name;
+  std::string mode;
+  std::string hash;
+  std::string content;
+  std::string name;
 
-    virtual ~Object() = default;
-    Object() = default;
+  virtual ~Object() = default;
+  Object() = default;
 
-    std::string getSha256();
-    void writeObjectToDisk();
-    bool isWrittenToDisk();
+  std::string getSha256();
+  void writeObjectToDisk();
+  bool isWrittenToDisk();
 
-    std::string typeName() const;
+  std::string typeName() const;
 
-    static std::string readFromDisk(const std::string& hash);
+  static std::string readFromDisk(const std::string &hash);
 };
 
 // ---------- Blob ----------
 class Blob : public Object {
 public:
-    Blob() = default;
+  Blob() = default;
 
-    Blob(const std::string& filename);
-    static Blob* fromFile(const std::string& filename);
-    void loadFromDisk(const std::string& hash);
-    void writeToWorkingTree();
-    bool createFile(const std::string& path);
-    bool deleteFile(const std::string& path);
-    bool overwriteFile(const std::string& path);
+  Blob(const std::string &filename);
+  static Blob *fromFile(const std::string &filename);
+  void loadFromDisk(const std::string &hash);
+  void writeToWorkingTree();
+  bool createFile(const std::string &path);
+  bool deleteFile(const std::string &path);
+  bool overwriteFile(const std::string &path);
 };
 
 // ---------- TreeNode ----------
 class TreeNode : public Object {
 public:
-    // Key = hash, Value = child object
-    std::unordered_map<std::string, Object*> children;
-    void loadFromDisk(const std::string& hash);
+  // Key = hash, Value = child object
+  std::unordered_map<std::string, Object *> children;
+  void loadFromDisk(const std::string &hash);
 };
 
 // ---------- Tree ----------
 class Tree {
 public:
-    TreeNode* root;
+  TreeNode *root;
 
-    Tree();
+  Tree();
 
-    void insertBlob(TreeNode* root,
-                const std::vector<std::string>& path,
-                int level,
-                const std::string& hash,
-                const std::string& mode);
+  void insertBlob(TreeNode *root, const std::vector<std::string> &path,
+                  int level, const std::string &hash, const std::string &mode);
 
-    void writeTreeToDisk(TreeNode* root);
-    void buildFromIndex();
-    void loadTreeFromDisk(const std::string& hash);
-    void writeToWorkingDirectory(TreeNode* root,std::string path);
-    void deleteFromWorkingDirectory(TreeNode* root,std::string path);
-    std::unordered_map<std::string,std::pair<std::string,std::string>> flatten();
-    void flattenHelper(TreeNode* root,std::unordered_map<std::string,std::pair<std::string,std::string>>& entries);
+  void writeTreeToDisk(TreeNode *root);
+  void buildFromIndex();
+  void loadTreeFromDisk(const std::string &hash);
+  void writeToWorkingDirectory(TreeNode *root, std::string path);
+  void deleteFromWorkingDirectory(TreeNode *root, std::string path);
+  std::unordered_map<std::string, std::pair<std::string, std::string>>
+  flatten();
+  void flattenHelper(
+      TreeNode *root,
+      std::unordered_map<std::string, std::pair<std::string, std::string>>
+          &entries);
 
-    static Tree* write();
-    static void diff(TreeNode* first, TreeNode* second,
-                     std::unordered_map<std::string, std::vector<std::pair<Object*, std::string>>>& summary,
-                     const std::string& path);
-    static void buildFromDiff(std::unordered_map<std::string, std::vector<std::pair<Object*, std::string>>>& diff);
+  static Tree *write();
+  static void
+  diff(TreeNode *first, TreeNode *second,
+       std::unordered_map<
+           std::string, std::vector<std::pair<Object *, std::string>>> &summary,
+       const std::string &path);
+  static void buildFromDiff(
+      std::unordered_map<std::string,
+                         std::vector<std::pair<Object *, std::string>>> &diff);
 };
 
-class Commit:public Object{
-  public:
-    Tree* tree;
-    Commit();
-    Commit(const std::string& message,const std::string& parent_hash);
-    Commit(const std::string& message,const std::string& parent1_hash,const std::string& parent2_hash);
-    void loadFromDisk(const std::string& hash);
+class Commit : public Object {
+public:
+  Tree *tree;
+  std::vector<std::string> parents;
+  Commit();
+  Commit(const std::string &message, const std::string &parent_hash);
+  Commit(const std::string &message, const std::string &parent1_hash,
+         const std::string &parent2_hash);
+  void loadFromDisk(const std::string &hash);
 
-    static Commit* create(const std::string& treeHash, const std::string& parent1Hash, 
-                         const std::string& parent2Hash, const std::string& message);
+  static Commit *create(const std::string &treeHash,
+                        const std::string &parent1Hash,
+                        const std::string &parent2Hash,
+                        const std::string &message);
 };
 
 #endif
-

--- a/src/commands/log.cpp
+++ b/src/commands/log.cpp
@@ -1,43 +1,46 @@
-#include <iostream>
+#include <ark.h>
+#include <cat-file.h>
+#include <config.h>
 #include <filesystem>
 #include <fstream>
-#include <string>
-#include <sstream>
-#include <cat-file.h>
-#include <ark.h>
+#include <iostream>
 #include <log.h>
 #include <objects.h>
+#include <queue>
 #include <ref.h>
-#include <config.h>
+#include <sstream>
+#include <string>
 
-void logBranch(const std::string& branchName) {
-    Ref ref;
-    Config config;
-    std::string commitHash = ref.getBranchHash(branchName);
-    
-    int depth = -1;
-    while (commitHash != NULL_HASH && (depth == -1 || depth--)) {
-        std::string content = Object::readFromDisk(commitHash);
-        std::vector<std::string> lines = config.split(content, '\n');
-        std::vector<std::string> data;
-        std::cout << "\033[1;33mcommit: " << commitHash << "\033[0m\n";
-        for (auto line : lines) {
-            std::vector<std::string> temp = config.split(line, ' ');
-            data.insert(data.end(), temp.begin(), temp.end());
-        }
-        commitHash = data[3];
-    }
+void logBranch(const std::string &branchName) {
+  Ref ref;
+  Config config;
+  std::string commitHash = ref.getBranchHash(branchName);
+  std::queue<std::string> commit_hashes_queue;
+
+  while (commitHash != NULL_HASH) {
+    std::string content = Object::readFromDisk(commitHash);
+    std::vector<std::string> lines = config.split(content, '\n');
+    std::vector<std::string> data;
+    std::cout << "\033[1;33mcommit: " << commitHash << "\033[0m\n";
+    Commit c;
+    c.loadFromDisk(commitHash);
+    for (auto parent : c.parents)
+      commit_hashes_queue.push(parent);
+    if (commit_hashes_queue.empty())
+      break;
+    commitHash = commit_hashes_queue.front();
+  }
 }
 
-int cmd_log(const std::vector<std::string> &args){
-    Ref ref;
-    std::string currentBranch = ref.getCurrentBranchName();
-    
-    if (currentBranch.empty()) {
-        std::cout << "HEAD is detached\n";
-        return 1;
-    }
-    
-    logBranch(currentBranch);
-    return 0;
+int cmd_log(const std::vector<std::string> &args) {
+  Ref ref;
+  std::string currentBranch = ref.getCurrentBranchName();
+
+  if (currentBranch.empty()) {
+    std::cout << "HEAD is detached\n";
+    return 1;
+  }
+
+  logBranch(currentBranch);
+  return 0;
 }

--- a/src/utils/objects.cpp
+++ b/src/utils/objects.cpp
@@ -1,7 +1,9 @@
 // represents a single file
+#include <_stdio.h>
 #include <ark.h>
 #include <cat-file.h>
 #include <compress.h>
+#include <config.h>
 #include <filesystem>
 #include <fstream>
 #include <hash-object.h>
@@ -10,10 +12,9 @@
 #include <iostream>
 #include <objects.h>
 #include <openssl/sha.h>
+#include <repository.h>
 #include <sstream>
 #include <string>
-#include <repository.h>
-#include <config.h>
 
 Blob::Blob(const std::string &filename) {
   std::ifstream file(filename, std::ios::binary);
@@ -32,9 +33,7 @@ Blob::Blob(const std::string &filename) {
   this->hash = this->getSha256();
 }
 
-Blob* Blob::fromFile(const std::string& filename) {
-  return new Blob(filename);
-}
+Blob *Blob::fromFile(const std::string &filename) { return new Blob(filename); }
 
 void Blob::loadFromDisk(const std::string &hash) {
   std::string content = Object::readFromDisk(hash);
@@ -250,8 +249,8 @@ void Tree::writeTreeToDisk(TreeNode *root) {
   root->writeObjectToDisk();
 }
 
-Tree* Tree::write() {
-  Tree* t = new Tree();
+Tree *Tree::write() {
+  Tree *t = new Tree();
   t->buildFromIndex();
   t->writeTreeToDisk(t->root);
   return t;
@@ -350,6 +349,30 @@ Commit::Commit(const std::string &message, const std::string &parent1_hash,
   this->hash = this->getSha256();
 }
 
+bool starts_with(std::string str, std::string prefix) {
+  if (prefix.size() > str.size())
+    return false;
+
+  if (str.substr(0, prefix.size()) != prefix)
+    return false;
+  return true;
+}
+
+std::vector<std::string> split(std::string s, char delimiter) {
+  std::vector<std::string> tokens;
+  std::string token;
+  for (char c : s) {
+    if (c == delimiter) {
+      tokens.push_back(token);
+      token = "";
+    } else {
+      token.push_back(c);
+    }
+  }
+  tokens.push_back(token);
+  return tokens;
+}
+
 void Commit::loadFromDisk(const std::string &hash) {
   if (hash == NULL_HASH)
     return;
@@ -359,30 +382,43 @@ void Commit::loadFromDisk(const std::string &hash) {
   getline(content_stream, line);
   Config config;
   std::vector<std::string> tree_info = config.split(line, ' ');
+
+  parents.clear();
+  line.clear();
+  getline(content_stream, line);
+  while (starts_with(line, "parent")) {
+    std::vector<std::string> values = split(line, ' ');
+    parents.push_back(values[1]);
+    line.clear();
+    getline(content_stream, line);
+  }
   this->tree->root->loadFromDisk(tree_info[1]);
 }
 
-Commit* Commit::create(const std::string& treeHash, const std::string& parent1Hash, 
-                      const std::string& parent2Hash, const std::string& message) {
-  Commit* commit = new Commit();
-  
+Commit *Commit::create(const std::string &treeHash,
+                       const std::string &parent1Hash,
+                       const std::string &parent2Hash,
+                       const std::string &message) {
+  Commit *commit = new Commit();
+
   commit->tree = new Tree();
   commit->tree->root->loadFromDisk(treeHash);
-  
+
   Config config;
   config.load();
   if (!config.hasUserConfig()) {
     std::cerr << "please provide user.name and user.email before committing.\n";
     exit(0);
   }
-  
+
   std::string name = config.getUserName();
   std::string email = config.getUserEmail();
-  long long timestamp = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-  
+  long long timestamp =
+      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+
   Repository repo;
   std::string timezone_offset = repo.getTimezoneOffset();
-  
+
   std::ostringstream buffer;
   buffer << "tree " << treeHash << "\n";
   if (!parent1Hash.empty()) {
@@ -391,35 +427,37 @@ Commit* Commit::create(const std::string& treeHash, const std::string& parent1Ha
   if (!parent2Hash.empty()) {
     buffer << "parent " << parent2Hash << "\n";
   }
-  buffer << "committer " << name << " <" << email << "> " << timestamp << " " << timezone_offset << "\n";
+  buffer << "committer " << name << " <" << email << "> " << timestamp << " "
+         << timezone_offset << "\n";
   buffer << message << "\n";
-  
+
   std::string raw_content = buffer.str();
-  commit->content = "commit " + std::to_string(raw_content.size()) + std::string("\0", 1) + raw_content;
+  commit->content = "commit " + std::to_string(raw_content.size()) +
+                    std::string("\0", 1) + raw_content;
   commit->hash = commit->getSha256();
   commit->writeObjectToDisk();
-  
+
   return commit;
 }
 
-std::string Object::readFromDisk(const std::string& hash) {
+std::string Object::readFromDisk(const std::string &hash) {
   Repository repo;
   std::string object_dir = repo.objectsDir() + "/" + hash.substr(0, 2) + "/";
   std::string object_file = object_dir + hash.substr(2);
-  
+
   if (!std::filesystem::exists(object_file)) {
     return "";
   }
-  
+
   std::ifstream in(object_file, std::ios::binary);
   if (!in) {
     return "";
   }
-  
+
   std::ostringstream buffer;
   buffer << in.rdbuf();
   std::string compressed = buffer.str();
-  
+
   return decompressObject(compressed);
 }
 
@@ -466,11 +504,11 @@ void Object::writeObjectToDisk() {
 }
 
 std::string Object::typeName() const {
-  if (dynamic_cast<Blob *>(const_cast<Object*>(this)))
+  if (dynamic_cast<Blob *>(const_cast<Object *>(this)))
     return "blob";
-  else if (dynamic_cast<TreeNode *>(const_cast<Object*>(this)))
+  else if (dynamic_cast<TreeNode *>(const_cast<Object *>(this)))
     return "tree";
-  else if (dynamic_cast<Commit *>(const_cast<Object*>(this)))
+  else if (dynamic_cast<Commit *>(const_cast<Object *>(this)))
     return "commit";
   else
     return "object";
@@ -478,7 +516,8 @@ std::string Object::typeName() const {
 
 void Tree::diff(
     TreeNode *first, TreeNode *second,
-    std::unordered_map<std::string, std::vector<std::pair<Object *, std::string>>> &summary,
+    std::unordered_map<std::string,
+                       std::vector<std::pair<Object *, std::string>>> &summary,
     const std::string &path) {
   if (!first && !second) {
     return;
@@ -522,8 +561,7 @@ void Tree::diff(
     Object *first_child =
         (first->children.count(key) ? first->children[key] : nullptr);
     Object *second_child =
-        (second->children.count(key) ? second->children[key]
-                                      : nullptr);
+        (second->children.count(key) ? second->children[key] : nullptr);
 
     std::string new_path = path + key + "/";
 
@@ -563,7 +601,8 @@ void Tree::diff(
 }
 
 void Tree::buildFromDiff(
-    std::unordered_map<std::string, std::vector<std::pair<Object *, std::string>>> &diff) {
+    std::unordered_map<std::string,
+                       std::vector<std::pair<Object *, std::string>>> &diff) {
   Repository repo;
   std::string repo_root = repo.root();
 


### PR DESCRIPTION
This is a fix for the issue #8 .

issue:
Log was causing segmentation fault because of its broken commit parsing logic, which resulted in a unexpected value going to the commitHash variable which bypassed the NULL_HASH check and resulted in segfault.

fix:
The issue is fixed by replacing the broken parsing logic with a proper parsing logic which uses Commit objects new updated loadFromDisk method that now also loads the fields by parsing the commit file properly.
So now we simply access the fields from the object instead of doing parsing in the log methods.